### PR TITLE
Build final release

### DIFF
--- a/ci/docker/cpi-release-build-env/Dockerfile
+++ b/ci/docker/cpi-release-build-env/Dockerfile
@@ -9,5 +9,6 @@ RUN curl -sSL -o /usr/local/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts
 RUN chmod +x /usr/local/bin/bosh
 
 ENV GOLANG_VERSION 1.8.3
-ADD https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz /blobstore/golang/
-RUN chmod 644 /blobstore/golang/go${GOLANG_VERSION}*.gz
+ADD https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz /downloads/golang/
+RUN chmod 644 /downloads/golang/go${GOLANG_VERSION}*.gz
+RUN mkdir /blobstore && chmod 755 /blobstore

--- a/ci/pipelines/cpi-release-pipeline.yml
+++ b/ci/pipelines/cpi-release-pipeline.yml
@@ -3,7 +3,8 @@ groups:
   - name: bosh-oracle-cpi-release
     jobs:
       - build-cpi
-      - build-cpi-release
+      - build-dev-cpi-release
+      - build-final-cpi-release
 
 jobs:
   - name: build-cpi
@@ -13,7 +14,7 @@ jobs:
       - task: unit-tests
         file: cpi-src/ci/tasks/unit-tests.yml
 
-  - name: build-cpi-release
+  - name: build-dev-cpi-release
     serial: true
     plan:
       - aggregate:
@@ -27,15 +28,29 @@ jobs:
       - task: build-dev-release-tarball
         file: cpi-release/ci/tasks/build-dev-release.yml
 
-      - put: oci-s3-compat-storage
+      - put: dev-release-bucket
         params:
-          file: artifacts/*.tgz
+          file: artifacts/dev_release/bosh-oracle-cpi-dev-*.tgz
+
+  - name: build-final-cpi-release
+    serial: true
+    plan:
+      - aggregate:
+         - {trigger: false, get: version-semver,   params: {bump: major}}
+         - {trigger: true, passed: [build-dev-cpi-release], get: cpi-release, resource: bosh-cpi-release-src}
+
+      - task: build-final-release-tarball
+        file: cpi-release/ci/tasks/build-final-release.yml
+
+      - put: final-release-bucket
+        params:
+          file: artifacts/release/bosh-oracle-cpi-*.tgz
 
 resources:
   - name: bosh-cpi-release-src
     type: git
     source:
-      uri: https://github.com/oracle/bosh-oracle-cpi-release.git 
+      uri: https://github.com/dmutreja/bosh-oracle-cpi-release.git
       branch: ((cpi-release-branch)) 
       username: ((github-user))
       password: ((github-password))
@@ -43,7 +58,7 @@ resources:
   - name: bosh-cpi-src
     type: git
     source:
-      uri: https://github.com/oracle/bosh-oracle-cpi.git
+      uri: https://github.com/dmutreja/bosh-oracle-cpi.git
       branch: master 
       username: ((github-user))
       password: ((github-password))
@@ -52,19 +67,30 @@ resources:
     type: semver
     source:
       driver: git
-      uri: https://github.com/oracle/bosh-oracle-cpi-release.git 
+      uri: https://github.com/dmutreja/bosh-oracle-cpi-release.git
       username: ((github-user))
       password: ((github-password))
       branch: version
       file: version
       initial_version: 0.0.20
 
-  - name: oci-s3-compat-storage
+  - name: dev-release-bucket
     type: s3
     source:
        endpoint: https://((namespace)).compat.objectstorage.((region)).oraclecloud.com
        region_name: ((region))
-       bucket: ((cpi-release-bucket))
+       bucket: ((cpi-dev-release-bucket))
+       regexp: bosh-oracle-cpi-(.*).tgz
+       access_key_id: ((s3-access-key-id))
+       secret_access_key: ((s3-secret-access-key))
+       private: true
+
+  - name: final-release-bucket
+    type: s3
+    source:
+       endpoint: https://((namespace)).compat.objectstorage.((region)).oraclecloud.com
+       region_name: ((region))
+       bucket: ((cpi-final-release-bucket))
        regexp: bosh-oracle-cpi-(.*).tgz
        access_key_id: ((s3-access-key-id))
        secret_access_key: ((s3-secret-access-key))

--- a/ci/tasks/add-blobs.sh
+++ b/ci/tasks/add-blobs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Adding blobs..."
+golang_distro=`basename /downloads/golang/go*.gz`
+bosh add-blob --dir ${release_dir} /downloads/golang/${golang_distro} golang/${golang_distro}

--- a/ci/tasks/build-final-release.sh
+++ b/ci/tasks/build-final-release.sh
@@ -4,7 +4,6 @@ set -e
 
 cpi_release_name="bosh-oracle-cpi"
 semver=`cat version-semver/number`
-golang_ver=1.8.3
 
 pwd=`pwd`
 
@@ -12,8 +11,8 @@ pwd=`pwd`
 release_dir=${pwd}/cpi-release
 
 #Outputs
-release_artifact_path=${pwd}/artifacts/dev_release
-tarball_name=${cpi_release_name}-dev-${semver}.tgz
+release_artifact_path=${pwd}/artifacts/release
+tarball_name=${cpi_release_name}-${semver}.tgz
 tarball_path=${release_artifact_path}/${tarball_name}
 tarball_sha=${release_artifact_path}/${tarball_name}.sha1
 
@@ -24,8 +23,8 @@ bosh -v
 
 source ${release_dir}/ci/tasks/add-blobs.sh
 
-echo "Creating BOSH Oracle CPI Dev Release..."
-bosh create-release --dir ${release_dir} --name ${cpi_release_name} --version ${semver} --force --tarball="$tarball_path"
+echo "Creating BOSH Oracle CPI Final Release..."
+bosh create-release --final --dir ${release_dir} --name ${cpi_release_name} --version ${semver} --force --tarball="$tarball_path"
 
 echo -n $(sha1sum $tarball_path | awk '{print $1}') > ${tarball_sha} 
 

--- a/ci/tasks/build-final-release.yml
+++ b/ci/tasks/build-final-release.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: dmutreja/cpi-release-build-env
+    tag: "latest"
+inputs:
+  - name: cpi-release
+  - name: version-semver
+outputs:
+  - name: artifacts
+run:
+  path: cpi-release/ci/tasks/build-final-release.sh

--- a/config/final.yml
+++ b/config/final.yml
@@ -3,7 +3,7 @@ final_name: bosh-oracle-cpi
 blobstore:
   provider: local
   options:
-    blobstore_path: /change-to-valid-path
+    blobstore_path: /blobstore
 #TODO: Use OCI Object Store
 #blobstore:
 #  provider: s3


### PR DESCRIPTION
  - Added ci task to build final release
  - Configured config/final.yml to use `local` blobstore at /blobstore[1].  
  - Updated build docker image to create /blobstore
  - Refactored `bosh add-blob` command to its own script, add-blob.sh.

[1]Unlike Concourse, BOSH cli v2's s3client is currently unable to talk to Oracle Object Storage in AWS S3 compatible mode.  Will likely need enhancements in the s3client as it doesn't expose any property to allow signing requests. 