### PR TITLE
- Run BATs in the pipeline

### DIFF
--- a/ci/pipelines/cpi-release-pipeline.yml
+++ b/ci/pipelines/cpi-release-pipeline.yml
@@ -12,18 +12,16 @@ task-definitions:
       director_vcn: ((director-vcn))
       director_compartment_name: ((director-compartment-name))
       director_subnet_cidr: ((director-subnet-cidr))
+      bats_subnet1_cidr: ((bats-subnet1-cidr))
+      bats_subnet2_cidr: ((bats-subnet2-cidr))
 
   - &terraform-apply
-    put: oci-resources-setup
+    put: terraform-oci
     params:
       terraform_source: cpi-release-src/ci/terraform
       env_name:  oracle-pipeline-env
       var_files: [terraform-env/oci.vars]
       plugin_dir: /.terraform.d/plugins/linux_amd64
-
-  - &terraform-output
-    get: terraform-out
-    resource: oci-resources-setup
 
   - &prepare-test-config
     task: prepare-test-config
@@ -42,7 +40,7 @@ task-definitions:
       TEST_SPEC: "Test_Connect*"
 
   - &terraform-destroy
-    put: oci-resources-setup
+    put: terraform-oci
     params:
       terraform_source: cpi-release-src/ci/terraform
       env_name: oracle-pipeline-env
@@ -60,6 +58,9 @@ task-definitions:
     task: teardown-director
     file: cpi-release-src/ci/tasks/teardown-director.yml
 
+  - &run-bats
+    task: run-bats
+    file: cpi-release-src/ci/tasks/run-bats.yml
 
 groups:
   - name: bosh-oracle-cpi-release
@@ -67,7 +68,7 @@ groups:
       - run-unittests
       - run-ocitests
       - build-candidate
-      - create-director
+      - run-bats
       - build-final
 
 jobs:
@@ -89,7 +90,6 @@ jobs:
 
       - <<: *terraform-setup
       - <<: *terraform-apply
-      - <<: *terraform-output
       - <<: *prepare-test-config
       - do:
         - <<: *oci-tests
@@ -114,16 +114,18 @@ jobs:
       - put: dev-release-cpi
         params: {file: candidate/dev_release/bosh-oracle-cpi-dev-*.tgz}
 
-  - name: create-director
-    serial_groups: [run-bats, oci-resource-consumer]
+  - name: run-bats
+    serial_groups: [oci-resource-consumer]
     serial: true
     plan:
       - aggregate:
-        - {trigger: true, passed: [build-candidate], get: cpi-src, resource: bosh-cpi-src}
+        - {trigger: true, passed: [run-ocitests],    get: cpi-src, resource: bosh-cpi-src}
         - {trigger: true, passed: [build-candidate], get: cpi-release-src, resource: bosh-cpi-release-src}
+        - {trigger: true,                            get: stemcell, resource: oracle-ubuntu-stemcell}
         - {trigger: true,                            get: fixture-ssh-keys, resource: fixture-env, params: {file: oci-config.tgz, unpack: true}}
         - {trigger: false,                           get: bosh-release}
         - {trigger: false,                           get: dev-version-semver}
+        - {trigger: false,                           get: bats}
 
       - task: download-cpi
         file: cpi-release-src/ci/tasks/download-cpi.yml
@@ -138,21 +140,22 @@ jobs:
 
       - <<: *terraform-setup
       - <<: *terraform-apply
-      - <<: *terraform-output
       - <<: *prepare-test-config
       - do:
         - <<: *setup-director
+        - <<: *run-bats
         ensure:
           do:
             - <<: *teardown-director
             - <<: *terraform-destroy
 
   - name: build-final
+    serial_groups: [oci-resource-consumer]
     serial: true
     plan:
       - aggregate:
          - {trigger: false, get: final-version-semver,   params: {bump: major}}
-         - {trigger: true, passed: [run-ocitests, create-director], get: cpi-release-src, resource: bosh-cpi-release-src}
+         - {trigger: true, passed: [build-candidate], get: cpi-release-src, resource: bosh-cpi-release-src}
 
       - task: build-final-release
         file: cpi-release-src/ci/tasks/build-final-release.yml
@@ -193,7 +196,7 @@ resources:
        endpoint: https://((oracle-namespace)).compat.objectstorage.((oracle-region)).oraclecloud.com
        region_name: ((oracle-region))
        bucket: ((cpi-dev-release-bucket))
-       regexp: bosh-oracle-cpi-(.*).tgz
+       regexp: bosh-oracle-cpi-(.*)\.tgz
        access_key_id: ((oracle-s3-access-key-id))
        secret_access_key: ((oracle-s3-secret-access-key))
        private: true
@@ -204,7 +207,18 @@ resources:
        endpoint: https://((oracle-namespace)).compat.objectstorage.((oracle-region)).oraclecloud.com
        region_name: ((oracle-region))
        bucket: ((cpi-final-release-bucket))
-       regexp: bosh-oracle-cpi-(.*).tgz
+       regexp: bosh-oracle-cpi-(.*)\.tgz
+       access_key_id: ((oracle-s3-access-key-id))
+       secret_access_key: ((oracle-s3-secret-access-key))
+       private: true
+
+  - name: oracle-ubuntu-stemcell
+    type: s3
+    source:
+       endpoint: https://((oracle-namespace)).compat.objectstorage.((oracle-region)).oraclecloud.com
+       region_name: ((oracle-region))
+       bucket: ((stemcell-bucket))
+       regexp: light-oracle-ubuntu-stemcell-(.*)\.tgz
        access_key_id: ((oracle-s3-access-key-id))
        secret_access_key: ((oracle-s3-secret-access-key))
        private: true
@@ -237,12 +251,12 @@ resources:
        endpoint: https://((oracle-namespace)).compat.objectstorage.((oracle-region)).oraclecloud.com
        region_name: ((oracle-region))
        bucket: ((oracle-fixture-env-bucket-name))
-       regexp: (.*).tgz
+       regexp: (.*)\.tgz
        access_key_id: ((oracle-s3-access-key-id))
        secret_access_key: ((oracle-s3-secret-access-key))
        private: true
 
-  - name: oci-resources-setup
+  - name: terraform-oci
     type: terraform
     source:
        storage:
@@ -258,3 +272,9 @@ resources:
     type: bosh-io-release
     source:
       repository: cloudfoundry/bosh
+
+  - name: bats
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/bosh-acceptance-tests.git
+      branch: gocli-bats

--- a/ci/tasks/prepare-terraform-env.sh
+++ b/ci/tasks/prepare-terraform-env.sh
@@ -26,6 +26,8 @@ director_compartment_name: ${director_compartment_name}
 director_vcn: ${director_vcn}
 director_subnet_cidr: ${director_subnet_cidr}
 director_ad: ${director_ad}
+bats_subnet1_cidr: ${bats_subnet1_cidr}
+bats_subnet2_cidr: ${bats_subnet2_cidr}
 EOF
 
 echo "Done. Created: " ${vars_file}

--- a/ci/tasks/prepare-terraform-env.yml
+++ b/ci/tasks/prepare-terraform-env.yml
@@ -18,8 +18,9 @@ params:
   oracle_fingerprint:             replace-me
   oracle_apikey:                  replace-me
   oracle_apikey_file_name:        oci_api_key.pem
-  director_subnet_cidr:           10.0.10.0/24
+  director_subnet_cidr:           replace_me
   director_compartment_name:      replace_me
   director_vcn:                   replace_me
   director_ad:                    WZYX:PHX-AD-1
-
+  bats_subnet1_cidr:              replace_me
+  bats_subnet2_cidr:              replace_me

--- a/ci/tasks/prepare-test-config.sh
+++ b/ci/tasks/prepare-test-config.sh
@@ -5,7 +5,7 @@ set -e
 pwd=`pwd`
 
 #Inputs
-export TERRAFORM_OUTPUT=${pwd}/terraform-out/metadata
+export TERRAFORM_OUTPUT=${pwd}/terraform-oci/metadata
 templates_path=${pwd}/cpi-release-src/ci/templates
 keys=${pwd}/fixture-ssh-keys
 
@@ -29,3 +29,5 @@ erb -T '-' -r json ${templates_path}/ocitest-ini.erb >  ${output_dir}/config
 
 export userPublicKeyPath=${output_dir}/userkeys/id_rsa.pub
 erb -T '-' -r json ${templates_path}/create-env-vars.erb >  ${output_dir}/director-env-vars.yml
+
+erb -T '-' -r json ${templates_path}/bat.yml.erb >  ${output_dir}/bat.yml

--- a/ci/tasks/prepare-test-config.yml
+++ b/ci/tasks/prepare-test-config.yml
@@ -6,7 +6,7 @@ image_resource:
     repository: dmutreja/ubuntu-xenial-boshcliv2 
     tag: "latest"
 inputs:
-  - name: terraform-out
+  - name: terraform-oci
   - name: fixture-ssh-keys
   - name: cpi-release-src
 outputs:

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+cp /usr/local/bin/bosh /usr/local/bin/bosh2
+gem install bundle
+
+echo "Setting up artifacts..."
+cp ./stemcell/*.tgz stemcell.tgz
+
+# path to the stemcell you want to use for testing
+export BAT_STEMCELL="${PWD}/stemcell.tgz"
+
+# path to the bat yaml file which is used to generate the deployment manifest
+export BAT_DEPLOYMENT_SPEC="${PWD}/oci-config/bat.yml"
+
+# BOSH CLI executable path
+export BAT_BOSH_CLI=`which bosh2`
+
+export BAT_DNS_HOST=8.8.8.8
+
+# the name of infrastructure that is used by bosh deployment. Examples: aws, vsphere, openstack, warden.
+export BAT_INFRASTRUCTURE=oci
+
+# the type of networking being used: dynamic or manual.
+export BAT_NETWORKING="manual"
+
+# the path to ssh key, used by OS specs to ssh into BOSH VMs
+export BAT_PRIVATE_KEY="${PWD}/oci-config/userkeys/id_rsa"
+
+# Run tests with --fail-fast and skip cleanup in case of failure (optional)
+export BAT_DEBUG_MODE=
+
+env_vars="${PWD}/oci-config/director-env-vars.yml"
+creds_yml="${PWD}/deployment/creds.yml"
+
+export BOSH_ENVIRONMENT="$(bosh2 int ${env_vars} --path /internal_ip)"
+export BOSH_CLIENT=admin
+export BOSH_CLIENT_SECRET="$(bosh2 int ${env_vars} --path /admin_password)"
+export BOSH_CA_CERT="$(bosh2 int ${creds_yml} --path /director_ssl/ca)"
+
+echo "Using BOSH CLI version..."
+bosh2 -v
+
+echo "Targeting BOSH director..."
+bosh2 login
+
+pushd bats
+  echo "Installing gems..."
+  bundle install
+
+  echo "Running BOSH Acceptance Tests..."
+  bundle exec rspec spec --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage --tag ~changing_static_ip --tag ~network_reconfiguration --tag ~dns
+popd

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: dmutreja/ubuntu-xenial-boshcliv2
+    tag: "latest"
+inputs:
+  - name: cpi-release-src
+  - name: stemcell
+  - name: oci-config
+  - name: deployment
+  - name: bats
+run:
+  path: cpi-release-src/ci/tasks/run-bats.sh

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -9,20 +9,26 @@ state_filename="director-manifest-state.json"
 
 echo "Setting up artifacts..."
 cp ./candidate/*.tgz ${deployment_dir}/${cpi_release_name}.tgz
+cp ./stemcell/*.tgz ${deployment_dir}/stemcell.tgz
 cp ./bosh-release/*.tgz ${deployment_dir}/bosh-release.tgz
 cp ./cpi-release-src/bosh-deployment/bosh.yml ${deployment_dir}/${manifest_filename}
 cp ./cpi-release-src/bosh-deployment/cpi.yml ${deployment_dir}
 cp ./oci-config/director-env-vars.yml ${deployment_dir}
 
-# Use the candidate CPI
-local_cpi="local-cpi.yml"
-cat >"${deployment_dir}/${local_cpi}"<<EOF
+# Use the candidate artifacts
+local_yml="local.yml"
+cat >"${deployment_dir}/${local_yml}"<<EOF
 ---
 - type: replace
   path: /releases/name=bosh-oracle-cpi
   value:
     name: bosh-oracle-cpi
     url: file://${cpi_release_name}.tgz
+
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    url: file://stemcell.tgz
 EOF
 
 
@@ -43,7 +49,7 @@ pushd ${deployment_dir}
   ls -al 
 
   echo "Deploying BOSH Director..."
-  bosh create-env --ops-file ./cpi.yml --ops-file ./${local_cpi} --vars-store ./creds.yml --state ${state_filename} --vars-file ./director-env-vars.yml ${manifest_filename}
+  bosh create-env --ops-file ./cpi.yml --ops-file ./${local_yml} --vars-store ./creds.yml --state ${state_filename} --vars-file ./director-env-vars.yml ${manifest_filename}
 
   trap - ERR
   finish

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -11,6 +11,7 @@ inputs:
   - name: bosh-release
   - name: candidate
   - name: oci-config
+  - name: stemcell
 outputs:
   - name: deployment
 run:

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -12,5 +12,5 @@ pushd ${deployment_dir}
   bosh -v
 
   echo "Deleting BOSH Director..."
-  bosh delete-env --ops-file ./cpi.yml --ops-file ./local-cpi.yml --vars-store ./creds.yml --state ${state_filename} --vars-file ./director-env-vars.yml ${manifest_filename}
+  bosh delete-env --ops-file ./cpi.yml --ops-file ./local.yml --vars-store ./creds.yml --state ${state_filename} --vars-file ./director-env-vars.yml ${manifest_filename}
 popd

--- a/ci/templates/bat.yml.erb
+++ b/ci/templates/bat.yml.erb
@@ -1,0 +1,44 @@
+<% properties = ENV.to_hash -%>
+<% if ENV['TERRAFORM_OUTPUT']
+     contents = JSON.parse(File.read(ENV['TERRAFORM_OUTPUT']))
+     properties = properties.merge(contents)
+   end
+-%>
+<%
+  ['oracle_user', 'oracle_tenancy', 'oracle_fingerprint', 'oracle_apikey', 'oracle_region',
+   'compartment_id', 'ad', 'vcn', 'subnet_name', 'subnet_cidr', 'subnet_gw','subnet_first_ip'].each do |val|
+    if properties[val].nil? || properties[val].empty?
+      raise "Missing environment variable: #{val}"
+    end
+  end
+-%>
+---
+cpi: oci
+properties:
+  stemcell:
+    name: light-oracle-ubuntu-stemcell
+    version: latest
+  instances: 1
+  instance_shape: 'VM.Standard1.2'
+  availability_domain: <%= properties['ad'] %>
+  networks:
+  - name: default
+    type: manual
+    static_ip: <%= properties['bats_subnet1_static_ip'] %> # Primary (private) IP assigned to the bat-release job vm (primary NIC), must be in the primary static range
+    cloud_properties:
+      vcn: <%= properties['vcn'] %>
+      subnet: <%= properties['bats_subnet1_name'] %>
+    cidr: <%= properties['bats_subnet1_cidr'] %>
+    reserved: ['<%= properties['bats_subnet1_reserved'] %>']
+    static: ['<%= properties['bats_subnet1_static'] %>']
+    gateway: <%= properties['bats_subnet1_gw'] %>
+  - name: second # Secondary network for testing jobs with multiple manual networks
+    type: manual
+    static_ip: <%= properties['bats_subnet2_static_ip'] %> # Primary (private) IP assigned to the bat-release job vm (primary NIC), must be in the primary static range
+    cloud_properties:
+      vcn: <%= properties['vcn'] %>
+      subnet: <%= properties['bats_subnet2_name'] %>
+    cidr: <%= properties['bats_subnet2_cidr'] %>
+    reserved: ['<%= properties['bats_subnet2_reserved'] %>']
+    static: ['<%= properties['bats_subnet2_static'] %>']
+    gateway: <%= properties['bats_subnet2_gw'] %>

--- a/ci/terraform/network.tf
+++ b/ci/terraform/network.tf
@@ -31,3 +31,27 @@ resource "oci_core_subnet" "director_subnet" {
   security_list_ids   = ["${oci_core_security_list.ci_public_all.id}"]
   prohibit_public_ip_on_vnic = false
 }
+
+resource "oci_core_subnet" "bats_subnet1" {
+  availability_domain = "${data.null_data_source.SetupConfig.inputs.ad_name}"
+  cidr_block          = "${var.bats_subnet1_cidr}"
+  display_name        = "ci_bats_subnet1_${replace(data.null_data_source.SetupConfig.inputs.ad_name, "-", "_")}"
+  dhcp_options_id     = "${data.null_data_source.VCN.inputs.dhcp_options_id}"
+  compartment_id      = "${data.null_data_source.SetupConfig.inputs.compartment_id}"
+  vcn_id              = "${data.null_data_source.VCN.inputs.id}"
+  route_table_id      = "${data.null_data_source.VCN.inputs.default_route_table_id}"
+  security_list_ids   = ["${oci_core_security_list.ci_public_all.id}"]
+  prohibit_public_ip_on_vnic = false
+}
+
+resource "oci_core_subnet" "bats_subnet2" {
+  availability_domain = "${data.null_data_source.SetupConfig.inputs.ad_name}"
+  cidr_block          = "${var.bats_subnet2_cidr}"
+  display_name        = "ci_bats_subnet2_${replace(data.null_data_source.SetupConfig.inputs.ad_name, "-", "_")}"
+  dhcp_options_id     = "${data.null_data_source.VCN.inputs.dhcp_options_id}"
+  compartment_id      = "${data.null_data_source.SetupConfig.inputs.compartment_id}"
+  vcn_id              = "${data.null_data_source.VCN.inputs.id}"
+  route_table_id      = "${data.null_data_source.VCN.inputs.default_route_table_id}"
+  security_list_ids   = ["${oci_core_security_list.ci_public_all.id}"]
+  prohibit_public_ip_on_vnic = false
+}

--- a/ci/terraform/output.tf
+++ b/ci/terraform/output.tf
@@ -27,6 +27,55 @@ output subnet_gw {
 output subnet_first_ip {
    value = "${cidrhost(oci_core_subnet.director_subnet.cidr_block, 2)}"
 }
+
+output bats_subnet1_name {
+   value = "${oci_core_subnet.bats_subnet1.display_name}"
+}
+
+output bats_subnet1_cidr {
+   value = "${oci_core_subnet.bats_subnet1.cidr_block}"
+}
+
+output bats_subnet1_gw {
+   value ="${cidrhost(oci_core_subnet.bats_subnet1.cidr_block, 1)}"
+}
+
+output bats_subnet1_reserved {
+   value = "${cidrhost(oci_core_subnet.bats_subnet1.cidr_block, 2)} - ${cidrhost(oci_core_subnet.bats_subnet1.cidr_block, 9)}"
+}
+
+output bats_subnet1_static {
+   value = "${cidrhost(oci_core_subnet.bats_subnet1.cidr_block, 10)} - ${cidrhost(oci_core_subnet.bats_subnet1.cidr_block, 30)}"
+}
+
+output bats_subnet1_static_ip {
+   value = "${cidrhost(oci_core_subnet.bats_subnet1.cidr_block, 30)}"
+}
+
+output bats_subnet2_name {
+   value = "${oci_core_subnet.bats_subnet2.display_name}"
+}
+
+output bats_subnet2_cidr {
+   value = "${oci_core_subnet.bats_subnet2.cidr_block}"
+}
+
+output bats_subnet2_gw {
+   value ="${cidrhost(oci_core_subnet.bats_subnet2.cidr_block, 1)}"
+}
+
+output bats_subnet2_reserved {
+   value = "${cidrhost(oci_core_subnet.bats_subnet2.cidr_block, 2)} - ${cidrhost(oci_core_subnet.bats_subnet2.cidr_block, 9)}"
+}
+
+output bats_subnet2_static {
+   value = "${cidrhost(oci_core_subnet.bats_subnet2.cidr_block, 10)} - ${cidrhost(oci_core_subnet.bats_subnet2.cidr_block, 30)}"
+}
+
+output bats_subnet2_static_ip {
+   value = "${cidrhost(oci_core_subnet.bats_subnet2.cidr_block, 30)}"
+}
+
 /*
 output director_subnet {
   value = <<EOS

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -19,9 +19,14 @@ variable "vcn_cidr" {
 }
 
 variable "director_subnet_cidr" {
-    default = "10.0.1.0/24"
 }
 
 variable "director_ad" {
     default  = "WZYX:PHX-AD-1"
+}
+
+variable "bats_subnet1_cidr" {
+}
+
+variable "bats_subnet2_cidr" {
 }


### PR DESCRIPTION
- Generate bat.yml using terraform/ruby template
- Rename create-director as run-bats
- Fetch the stemcell as an S3 resource
- Escape the file extension in the regexps
- Trigger BATs when there is a new stemcell
- build-final should execute after build-candidate
- Force user/pipeline to supply CIDR values for the 3 subnets that terraform creates
- BATs should use the user SSH key and not the one used by ocitests